### PR TITLE
Continuous checking required network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 node_modules
 .DS_Store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ const WEB3_PROVIDER = 'http://0.0.0.0:8545'
   }}
 />
 ```
-        
+
 
 ### Metamask
 
-Looks for injected web3 and provides an interface to the rest of the components. Also displays a nice HUD for users to see what account is logged in, what network they are on, and how much Ethereum they have. 
+Looks for injected web3 and provides an interface to the rest of the components. Also displays a nice HUD for users to see what account is logged in, what network they are on, and how much Ethereum they have.
 
 ```javascript
 <Metamask
-  /*config={{requiredNetwork:['Ropsten']}}*/
+  /*config={{DEBUG: false, requiredNetwork:['Ropsten']}}*/
   onUpdate={(state)=>{
     console.log("metamask state update:",state)
     if(state.web3Provider) {
@@ -142,7 +142,7 @@ Listens for events and parses down the chain. Use an **id** field for unique key
 
 ### Address
 
-Renders an address with the blockie (identicon) and the current balance in Eth. 
+Renders an address with the blockie (identicon) and the current balance in Eth.
 
 ```javascript
   <Address
@@ -171,8 +171,8 @@ Renders a button
 Renders an identicon for an address
 
 ```javascript
-    <Blockie 
-      address={someEthereumAddress} 
+    <Blockie
+      address={someEthereumAddress}
       config={{size:3}}
      />
 ```
@@ -194,4 +194,3 @@ Scales components based on a target screen width vs actual screen width. Get you
 Ether Jam Jam is a demo app I built that uses Dapparatus for meta transactions:
 
 [![etherjamjam](https://user-images.githubusercontent.com/2653167/46258946-4e6e0280-c48f-11e8-854d-261b9fd7d152.png)](https://youtu.be/cNcSXovVPdg)
-

--- a/src/dapparatus.js
+++ b/src/dapparatus.js
@@ -60,7 +60,6 @@ defaultConfig.blockieStyle = {
 };
 defaultConfig.requiredNetwork = [
   'Mainnet',
-  'xDai',
   'Unknown' //allow local RPC for testing
 ];
 

--- a/src/dapparatus.js
+++ b/src/dapparatus.js
@@ -59,8 +59,8 @@ defaultConfig.blockieStyle = {
   right: 15
 };
 defaultConfig.requiredNetwork = [
-  'Mainnet',
-  'Unknown' //allow local RPC for testing
+  'Unknown', //allow local RPC for testing
+  'Mainnet'
 ];
 
 let burnMetaAccount = ()=>{
@@ -82,7 +82,7 @@ class Dapparatus extends Component {
 
     if (props.config) {
       config = deepmerge(config, props.config);
-      if (props.config.requiredNetwork) {
+      if (props.config.requiredNetwork && props.config.requiredNetwork[0] != "") {
         config.requiredNetwork = props.config.requiredNetwork;
       }
     }
@@ -121,9 +121,10 @@ class Dapparatus extends Component {
   }
   componentDidUpdate() {
     if (this.props.config) {
+      const requiredNetwork = this.props.config.requiredNetwork;
       let config = this.state.config;
-      if (config.requiredNetwork != this.props.config.requiredNetwork){
-        config.requiredNetwork = this.props.config.requiredNetwork;
+      if (requiredNetwork && requiredNetwork[0] != "" && config.requiredNetwork != requiredNetwork){
+        config.requiredNetwork = requiredNetwork;
         this.setState({config: config});
       }
     }

--- a/src/dapparatus.js
+++ b/src/dapparatus.js
@@ -119,6 +119,15 @@ class Dapparatus extends Component {
       web3Fellback: false
     };
   }
+  componentDidUpdate() {
+    if (this.props.config) {
+      let config = this.state.config;
+      if (config.requiredNetwork != this.props.config.requiredNetwork){
+        config.requiredNetwork = this.props.config.requiredNetwork;
+        this.setState({config: config});
+      }
+    }
+  }
   componentDidMount() {
     interval = setInterval(
       this.checkMetamask.bind(this),

--- a/src/dapparatus.js
+++ b/src/dapparatus.js
@@ -59,8 +59,8 @@ defaultConfig.blockieStyle = {
   right: 15
 };
 defaultConfig.requiredNetwork = [
-  'Unknown', //allow local RPC for testing
-  'Mainnet'
+  'Mainnet',
+  'Unknown' //allow local RPC for testing
 ];
 
 let burnMetaAccount = ()=>{
@@ -417,7 +417,7 @@ class Dapparatus extends Component {
     } else if (this.state.status == 'ready') {
       let requiredNetworkText = '';
       for (let n in this.state.config.requiredNetwork) {
-        if (this.state.config.requiredNetwork[n] != 'Unknown') {
+        if (this.state.config.requiredNetwork[n] != 'Unknown' && this.state.config.requiredNetwork[n] != '') {
           if (requiredNetworkText != '') requiredNetworkText += 'or ';
           requiredNetworkText += this.state.config.requiredNetwork[n] + ' ';
         }

--- a/src/dapparatus.js
+++ b/src/dapparatus.js
@@ -422,7 +422,7 @@ class Dapparatus extends Component {
           requiredNetworkText += this.state.config.requiredNetwork[n] + ' ';
         }
       }
-      if (
+      if (!this.state.metaAccount &&
         this.state.config.requiredNetwork &&
         this.state.config.requiredNetwork.indexOf(this.state.network) < 0
       ) {

--- a/src/metamask.js
+++ b/src/metamask.js
@@ -72,6 +72,15 @@ class Metamask extends Component {
       lastBlockTime: 0
     };
   }
+  componentDidUpdate() {
+    if (this.props.config) {
+      let config = this.state.config;
+      if (config.requiredNetwork != this.props.config.requiredNetwork){
+        config.requiredNetwork = this.props.config.requiredNetwork;
+        this.setState({config: config});
+      }
+    }
+  }
   componentDidMount() {
     interval = setInterval(
       this.checkMetamask.bind(this),

--- a/src/metamask.js
+++ b/src/metamask.js
@@ -49,8 +49,8 @@ defaultConfig.blockieStyle = {
   right: 15
 };
 defaultConfig.requiredNetwork = [
-  'Mainnet',
-  'Unknown' //allow local RPC for testing
+  'Unknown', //allow local RPC for testing
+  'Mainnet'
 ];
 class Metamask extends Component {
   constructor(props) {
@@ -58,7 +58,7 @@ class Metamask extends Component {
     let config = defaultConfig;
     if (props.config) {
       config = deepmerge(config, props.config);
-      if (props.config.requiredNetwork) {
+      if (props.config.requiredNetwork && props.config.requiredNetwork[0] != "") {
         config.requiredNetwork = props.config.requiredNetwork;
       }
     }
@@ -74,9 +74,10 @@ class Metamask extends Component {
   }
   componentDidUpdate() {
     if (this.props.config) {
+      const requiredNetwork = this.props.config.requiredNetwork;
       let config = this.state.config;
-      if (config.requiredNetwork != this.props.config.requiredNetwork){
-        config.requiredNetwork = this.props.config.requiredNetwork;
+      if (requiredNetwork && requiredNetwork[0] != "" && config.requiredNetwork != requiredNetwork){
+        config.requiredNetwork = requiredNetwork;
         this.setState({config: config});
       }
     }

--- a/src/metamask.js
+++ b/src/metamask.js
@@ -49,8 +49,8 @@ defaultConfig.blockieStyle = {
   right: 15
 };
 defaultConfig.requiredNetwork = [
-  'Unknown', //allow local RPC for testing
-  'Mainnet'
+  'Mainnet',
+  'Unknown' //allow local RPC for testing
 ];
 class Metamask extends Component {
   constructor(props) {
@@ -283,7 +283,7 @@ class Metamask extends Component {
     } else if (this.state.status == 'ready') {
       let requiredNetworkText = '';
       for (let n in this.state.config.requiredNetwork) {
-        if (this.state.config.requiredNetwork[n] != 'Unknown') {
+        if (this.state.config.requiredNetwork[n] != 'Unknown' && this.state.config.requiredNetwork[n] != '') {
           if (requiredNetworkText != '') requiredNetworkText += 'or ';
           requiredNetworkText += this.state.config.requiredNetwork[n] + ' ';
         }


### PR DESCRIPTION
This Fixes #8 
Now, the required network can be changed on-the-fly, and the page only re-loads when the user changes the network in metamask. It also preserves the component's default values until a network value is passed.